### PR TITLE
fix: if the username is a slack id, simply return it

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,14 @@ found Slack user @gleb ID: U12345678
 ...
 ```
 
+If you pass Slack user IDs (they start with `U`), they will simply be returned
+
+```shell
+$ npx cypress-slack-notify --find-user @U12345678
+already is a Slack user ID U12345678
+...
+```
+
 ## Find a single Slack user by its Slack ID
 
 ```shell

--- a/src/users.js
+++ b/src/users.js
@@ -19,6 +19,10 @@ function getSlackClient() {
   return web
 }
 
+function isSlackUserId(s) {
+  return typeof s === 'string' && s.startsWith('U')
+}
+
 async function fetchSlackUsers() {
   const web = getSlackClient()
   if (!web) {
@@ -84,8 +88,13 @@ async function findSlackUsers(usernames) {
   const normalizedUsernames = usernames.map((s) => s.trim()).filter(Boolean)
 
   const ids = normalizedUsernames.map((uname) => {
-    // the username should not include "@"
+    // the username should not start "@"
     const username = uname.startsWith('@') ? uname.slice(1) : uname
+
+    if (isSlackUserId(username)) {
+      console.log('already is a Slack user ID %s', username)
+      return username
+    }
 
     const id = users[username]
     debug('Slack user "%s" id %s', username, id)


### PR DESCRIPTION
If you pass Slack user IDs (they start with `U`), they will simply be returned

```shell
$ npx cypress-slack-notify --find-user @U12345678
already is a Slack user ID U12345678
...
```